### PR TITLE
Fix URL prefixes in 002_gz.yaml for image and call-to-action selectors

### DIFF
--- a/crawler_configs/simple/002_gz.yaml
+++ b/crawler_configs/simple/002_gz.yaml
@@ -22,12 +22,12 @@ selectors:
   image_url:
     selector: "div.PictureContainer img"
     attribute: "src"
-    prefix: "https://www.goslarsche.de/lokales/Goslar"
+    prefix: "https://www.goslarsche.de"
 
   call_to_action_url:
     selector: "h2.article-heading a"
     attribute: "href"
-    prefix: "https://www.goslarsche.de/lokales/Goslar"
+    prefix: "https://www.goslarsche.de"
 
 output:
   single:


### PR DESCRIPTION
URL Fixes for Goslarsche.de

-> Prefix Indexview: /lokales/Goslar entfernt
-> Prefix Image-URL: /lokales/Goslar entfernt